### PR TITLE
Fix key bindings in vi mode and add compatibility for Fisher 4.2.0+

### DIFF
--- a/conf.d/plugin-bang-bang.fish
+++ b/conf.d/plugin-bang-bang.fish
@@ -1,0 +1,16 @@
+bind ! __history_previous_command
+bind '$' __history_previous_command_arguments
+
+# set up the same key bindings for insert mode if using fish_vi_key_bindings
+if test "$fish_key_bindings" = 'fish_vi_key_bindings'
+    bind --mode insert ! __history_previous_command
+    bind --mode insert '$' __history_previous_command_arguments
+end
+
+function _plugin-bang-bang_uninstall --on-event plugin-bang-bang_uninstall
+    bind --erase --all !
+    bind --erase --all '$'
+    echo "plugin-bang-bang key bindings removed"
+
+    functions --erase _plugin-bang-bang_uninstall
+end

--- a/conf.d/plugin-bang-bang.fish
+++ b/conf.d/plugin-bang-bang.fish
@@ -10,7 +10,5 @@ end
 function _plugin-bang-bang_uninstall --on-event plugin-bang-bang_uninstall
     bind --erase --all !
     bind --erase --all '$'
-    echo "plugin-bang-bang key bindings removed"
-
     functions --erase _plugin-bang-bang_uninstall
 end

--- a/hooks/uninstall.fish
+++ b/hooks/uninstall.fish
@@ -1,0 +1,2 @@
+bind --erase --all !
+bind --erase --all '$'

--- a/key_bindings.fish
+++ b/key_bindings.fish
@@ -1,2 +1,0 @@
-bind ! __history_previous_command
-bind '$' __history_previous_command_arguments


### PR DESCRIPTION
Fixes #4, #7.

I also added a Fisher uninstall function which erases the key bindings on removal via Fisher.