### PR TITLE
add support for fish hybrid key bindings

### DIFF
--- a/conf.d/plugin-bang-bang.fish
+++ b/conf.d/plugin-bang-bang.fish
@@ -1,10 +1,9 @@
-bind ! __history_previous_command
-bind '$' __history_previous_command_arguments
-
-# set up the same key bindings for insert mode if using fish_vi_key_bindings
 if test "$fish_key_bindings" != fish_default_key_bindings
     bind --mode insert ! __history_previous_command
     bind --mode insert '$' __history_previous_command_arguments
+else
+    bind ! __history_previous_command
+    bind '$' __history_previous_command_arguments
 end
 
 function _plugin-bang-bang_uninstall --on-event plugin-bang-bang_uninstall

--- a/conf.d/plugin-bang-bang.fish
+++ b/conf.d/plugin-bang-bang.fish
@@ -2,7 +2,7 @@ bind ! __history_previous_command
 bind '$' __history_previous_command_arguments
 
 # set up the same key bindings for insert mode if using fish_vi_key_bindings
-if test "$fish_key_bindings" = 'fish_vi_key_bindings'
+if test "$fish_key_bindings" != fish_default_key_bindings
     bind --mode insert ! __history_previous_command
     bind --mode insert '$' __history_previous_command_arguments
 end


### PR DESCRIPTION
fish_hybrid_key_bindings https://github.com/fish-shell/fish-shell/blob/master/share/functions/fish_hybrid_key_bindings.fish

Also fixes "$" overriding existing normal mode (for vi/hybrid) key binding (to go to end of line)