### PR TITLE
Multiple improvements over key binding logic

### DIFF
--- a/conf.d/plugin-bang-bang.fish
+++ b/conf.d/plugin-bang-bang.fish
@@ -1,10 +1,14 @@
-bind ! __history_previous_command
-bind '$' __history_previous_command_arguments
-
-# set up the same key bindings for insert mode if using fish_vi_key_bindings
-if test "$fish_key_bindings" = 'fish_vi_key_bindings'
-    bind --mode insert ! __history_previous_command
-    bind --mode insert '$' __history_previous_command_arguments
+function _plugin-bang-bang_key_bindings --on-variable fish_key_bindings
+    bind --erase --all !
+    bind --erase --all '$'
+    switch "$fish_key_bindings"
+    case 'fish_default_key_bindings'
+        bind --mode default ! __history_previous_command
+        bind --mode default '$' __history_previous_command_arguments
+    case 'fish_vi_key_bindings' 'fish_hybrid_key_bindings'
+        bind --mode insert ! __history_previous_command
+        bind --mode insert '$' __history_previous_command_arguments
+    end
 end
 
 function _plugin-bang-bang_uninstall --on-event plugin-bang-bang_uninstall
@@ -12,3 +16,5 @@ function _plugin-bang-bang_uninstall --on-event plugin-bang-bang_uninstall
     bind --erase --all '$'
     functions --erase _plugin-bang-bang_uninstall
 end
+
+_plugin-bang-bang_key_bindings


### PR DESCRIPTION
* Dynamically reset key bindings when `$fish_key_bindings` changes

* Add support for `fish_hybrid_key_bindings` mode

* Fix the bug that end-of-line `$` is overridden by the plugin in fish vim/hybrid command mode