### PR TITLE
Fix issues on multiline commandline buffers

### DIFF
--- a/functions/__history_previous_command.fish
+++ b/functions/__history_previous_command.fish
@@ -1,8 +1,9 @@
 function __history_previous_command
-  switch (commandline -t)
+  switch (commandline --current-token)[-1]
   case "!"
-    commandline -t $history[1]; commandline -f repaint
+    commandline --current-token $history[1]
+    commandline --function repaint
   case "*"
-    commandline -i !
+    commandline --insert !
   end
 end

--- a/functions/__history_previous_command_arguments.fish
+++ b/functions/__history_previous_command_arguments.fish
@@ -1,9 +1,9 @@
 function __history_previous_command_arguments
-  switch (commandline -t)
+  switch (commandline --current-token)[-1]
   case "!"
-    commandline -t ""
-    commandline -f history-token-search-backward
+    commandline --current-token ""
+    commandline --function history-token-search-backward
   case "*"
-    commandline -i '$'
+    commandline --insert '$'
   end
 end


### PR DESCRIPTION
The functions' `switch` statement threw an error in certain situations when entering a `$` character inside a multiline commandline buffer (i.e. when writing a for loop) which made it impossible to reference shell variables.

This PR should fix that (credit to https://github.com/fish-shell/fish-shell/issues/288#issuecomment-591679913)